### PR TITLE
Toggle use produce block v3

### DIFF
--- a/cluster/scripts/lodestar/run-validator.sh
+++ b/cluster/scripts/lodestar/run-validator.sh
@@ -19,6 +19,10 @@ function run_lodestar_validator() {
         VALIDATOR_EXTRA_OPTS="--builder=true --builder.selection=builderalways $VALIDATOR_EXTRA_OPTS"
     fi
 
+    if [ "$USE_PRODUCE_BLOCK_V3" = true ]; then
+        VALIDATOR_EXTRA_OPTS="--useProduceBlockV3=true $VALIDATOR_EXTRA_OPTS"
+    fi
+
     if [ -n "$VALIDATOR_EXTRA_OPTS" ]; then
         flags="${flags} ${VALIDATOR_EXTRA_OPTS}"
     fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - EXIT_EPOCH
       - VALIDATOR_EXTRA_OPTS
       - CUSTOM_BEACON_NODE_URLS
+      - USE_PRODUCE_BLOCK_V3=false
     healthcheck:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:
@@ -58,6 +59,7 @@ services:
       - EXIT_EPOCH
       - VALIDATOR_EXTRA_OPTS
       - CUSTOM_BEACON_NODE_URLS
+      - USE_PRODUCE_BLOCK_V3=false
     healthcheck:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:
@@ -89,6 +91,7 @@ services:
       - EXIT_EPOCH
       - VALIDATOR_EXTRA_OPTS
       - CUSTOM_BEACON_NODE_URLS
+      - USE_PRODUCE_BLOCK_V3=false
     healthcheck:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:
@@ -120,6 +123,7 @@ services:
       - EXIT_EPOCH
       - VALIDATOR_EXTRA_OPTS
       - CUSTOM_BEACON_NODE_URLS
+      - USE_PRODUCE_BLOCK_V3=false
     healthcheck:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:
@@ -151,6 +155,7 @@ services:
       - EXIT_EPOCH
       - VALIDATOR_EXTRA_OPTS
       - CUSTOM_BEACON_NODE_URLS
+      - USE_PRODUCE_BLOCK_V3=false
     healthcheck:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:


### PR DESCRIPTION
Toggle use produce block v3 for lodestar validator. User must set the environment variable `USE_PRODUCE_BLOCK_V3` to `true`