### PR TITLE
Explicitely add architectures to dappnode_package.json

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -24,6 +24,7 @@
   "links": {
     "homepage": "https://obol.tech/"
   },
+  "architectures": ["linux/amd64", "linux/arm64"],
   "backup": [
     {
       "name": "charon1",


### PR DESCRIPTION
This PR adds amd64 and arm64 to the top level dappnode_package.json to build the package for both architectures. Right now it is not available on ARM.