### PR TITLE
Do not use variable substitution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - EXIT_EPOCH=256
       - VALIDATOR_EXTRA_OPTS
       - CUSTOM_BEACON_NODE_URLS
-      - CHARON_NICKNAME=${CHARON_NICKNAME:-}
+      - CHARON_NICKNAME
     healthcheck:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:
@@ -59,7 +59,7 @@ services:
       - EXIT_EPOCH=256
       - VALIDATOR_EXTRA_OPTS
       - CUSTOM_BEACON_NODE_URLS
-      - CHARON_NICKNAME=${CHARON_NICKNAME:-}
+      - CHARON_NICKNAME
     healthcheck:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:
@@ -91,7 +91,7 @@ services:
       - EXIT_EPOCH=256
       - VALIDATOR_EXTRA_OPTS
       - CUSTOM_BEACON_NODE_URLS
-      - CHARON_NICKNAME=${CHARON_NICKNAME:-}
+      - CHARON_NICKNAME
     healthcheck:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:
@@ -123,7 +123,7 @@ services:
       - EXIT_EPOCH=256
       - VALIDATOR_EXTRA_OPTS
       - CUSTOM_BEACON_NODE_URLS
-      - CHARON_NICKNAME=${CHARON_NICKNAME:-}
+      - CHARON_NICKNAME
     healthcheck:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:
@@ -155,7 +155,7 @@ services:
       - EXIT_EPOCH=256
       - VALIDATOR_EXTRA_OPTS
       - CUSTOM_BEACON_NODE_URLS
-      - CHARON_NICKNAME=${CHARON_NICKNAME:-}
+      - CHARON_NICKNAME
     healthcheck:
       test: wget -qO- http://localhost:3620/readyz
     security_opt:


### PR DESCRIPTION
Do not use variable substitution, not allowed by dappmanager `dockerCompose` module. See https://github.com/dappnode/DNP_DAPPMANAGER/blob/fe8d01191f09d8f3426cda1de54275f1f89acf98/packages/dockerCompose/src/verify.ts#L59