### PR TITLE
Simplify lodestar bin

### DIFF
--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
 
 RUN mkdir -p /opt/validator/bin /usr/local/bin/scripts/charon /usr/local/bin/scripts/lodestar && \
     curl -L https://github.com/ChainSafe/lodestar/releases/download/${VALIDATOR_CLIENT_VERSION}/lodestar-${VALIDATOR_CLIENT_VERSION}-linux-${TARGETARCH}.tar.gz | tar -xz -C /opt/validator/bin && \
-    mv /opt/validator/bin/lodestar /opt/validator/bin/lodestar-${TARGETARCH} && chmod +x /opt/validator/bin/lodestar-${TARGETARCH}
+    chmod +x /opt/validator/bin/lodestar
 
 COPY scripts /usr/local/bin/scripts
 COPY supervisord.conf /etc/supervisord.conf


### PR DESCRIPTION
we had the following error when trying to exit validators:

```
/usr/local/bin/scripts/lodestar/sign-exit.sh: line 44: /opt/validator/bin/lodestar: No such file or directory
```

This was because in the Dockerfile, the lodestar bin was renamed depending on the arch & not taken into account later. Simplified the Dockerfile so we dont rename the bin and we call it correctly later